### PR TITLE
ci(github-actions): declare explicit read-only permissions for semantic-pr (contents, pull-requests)

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,4 +1,6 @@
 name: Semantic Pull Request
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,6 +1,7 @@
 name: Semantic Pull Request
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -30,3 +31,6 @@ jobs:
             revert
             style
             test
+          scopes: |
+            deps
+            github-actions


### PR DESCRIPTION
Potential fix for [https://github.com/Aesthermortis/Privacy-Guard/security/code-scanning/2](https://github.com/Aesthermortis/Privacy-Guard/security/code-scanning/2)

To address this issue, add a `permissions` block to the workflow file. The block should specify only the permissions required to run the semantic pull request linting job, which typically means granting read-only access to `contents` (the repo source code) and, if the action does not need to write to pull requests or issues, not granting additional permissions. The recommended minimal block is:

```yaml
permissions:
  contents: read
```

Add the block immediately after the workflow's `name`, at the root level in `.github/workflows/semantic-pr.yml`. No imports or other regions require modification. No additional dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
