### PR TITLE
fix: preserve YouTube timestamps and allow start param in URL cleaning

### DIFF
--- a/src/url/cleaner.js
+++ b/src/url/cleaner.js
@@ -177,14 +177,21 @@ export const URLCleaner = {
       // Convert shorts to watch
       const id = u.pathname.split("/")[2];
       if (id) {
+        // Capture t from query or hash (#t=...)
+        const keepT = u.searchParams.get("t") || (u.hash.match(/(?:^|[#&])t=([^&]+)/)?.[1] ?? "");
         u.pathname = "/watch";
         u.search = "";
         u.searchParams.set("v", id);
+        if (keepT) {
+          u.searchParams.set("t", keepT);
+        }
+        u.hash = "";
       }
     }
     if (u.pathname === "/watch") {
-      const allow = new Set(["v", "t", "list", "index"]);
+      const allow = new Set(["v", "t", "start", "list", "index"]);
       this.stripParams(u, allow, false);
+
       const shareParams = ["si", "pp", "feature", "ab_channel"];
       for (const name of shareParams) {
         u.searchParams.delete(name);

--- a/tests/unit/privacy-guard.test.js
+++ b/tests/unit/privacy-guard.test.js
@@ -75,6 +75,30 @@ describe("URLCleaner.cleanHref", () => {
       "https://www.youtube.com/watch?v=abc123&feature=share&ab_channel=TestChannel&si=foo&pp=some";
     expect(URLCleaner.cleanHref(href)).toBe("https://www.youtube.com/watch?v=abc123");
   });
+
+  test("preserves timestamp when converting YouTube shorts URL", () => {
+    const href = "https://www.youtube.com/shorts/shortId?t=10";
+    const cleaned = URLCleaner.cleanHref(href);
+    expect(cleaned).toBe("https://www.youtube.com/watch?v=shortId&t=10");
+  });
+
+  test("preserves timestamp in hash when converting YouTube shorts URL", () => {
+    const href = "https://www.youtube.com/shorts/shortId#t=1m30s";
+    const cleaned = URLCleaner.cleanHref(href);
+    expect(cleaned).toBe("https://www.youtube.com/watch?v=shortId&t=1m30s");
+  });
+
+  test("preserves start parameter in YouTube watch URL", () => {
+    const href = "https://www.youtube.com/watch?v=abc123&start=42&feature=share&si=xyz";
+    const cleaned = URLCleaner.cleanHref(href);
+    expect(cleaned).toBe("https://www.youtube.com/watch?v=abc123&start=42");
+  });
+
+  test("cleans youtu.be URL with timestamp and share params", () => {
+    const href = "https://youtu.be/abc123?t=45&si=xyz";
+    const cleaned = URLCleaner.cleanHref(href);
+    expect(cleaned).toBe("https://www.youtube.com/watch?v=abc123&t=45");
+  });
 });
 
 describe("PrivacyGuard.neutralizeScript", () => {


### PR DESCRIPTION
This commit enhances the YouTube URL cleaning logic with several improvements:

- Timestamps (`t=...`) are now preserved when converting a `/shorts/` URL to a `/watch` URL. This includes handling timestamps present in the URL hash (e.g., `#t=1m30s`).
- The `start` parameter is now included in the allowlist for YouTube watch URLs, preventing it from being stripped.
- The cleaning of YouTube-specific sharing parameters (si, pp, feature, ab_channel) is now handled within the `cleanYouTube` function to avoid side effects on other domains.